### PR TITLE
fix app yml not have embeddings item cause req search 404

### DIFF
--- a/apps/devices/api.yml
+++ b/apps/devices/api.yml
@@ -1,2 +1,3 @@
 # Index path
 path: /data/sources/devices
+embeddings:

--- a/apps/sports/api.yml
+++ b/apps/sports/api.yml
@@ -1,2 +1,3 @@
 # Index path
 path: /data/sources/sports
+embeddings:


### PR DESCRIPTION
Add "embeddings:" in api.yml file close issue:[#10]
