### PR TITLE
fix sports index-simple.yml path not same issue

### DIFF
--- a/apps/sports/index-simple.yml
+++ b/apps/sports/index-simple.yml
@@ -28,7 +28,7 @@ labels:
     values: [Baseball, Basketball, Football, Hockey]
 
 # Index path
-path: sports/data
+path: /data/sources/sports
 
 # Embeddings index configuration
 embeddings:


### PR DESCRIPTION
index-simple.yml path value is " sports/data" but index.yaml path value is "/data/sources/sports" if not start service in /data/sources path cause not use same database file